### PR TITLE
Add support for case statements

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -144,6 +144,10 @@
     'name': 'keyword.other.order.sql'
   }
   {
+    'match': '(?i)\\b(case|when|then|else|end)\\b'
+    'name': 'keyword.other.case.sql'
+  }
+  {
     'match': '\\*'
     'name': 'keyword.operator.star.sql'
   }


### PR DESCRIPTION
Add highlight for statements that look like the following (supported by Transact-SQL and PL/SQL, among others):

``` sql
CASE [ expression ]
   WHEN condition_1 THEN result_1
   WHEN condition_2 THEN result_2
   ...
   WHEN condition_n THEN result_n
   ELSE result
END
```
