### PR TITLE
Removed MySQL comments

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -213,23 +213,6 @@
         ]
       }
       {
-        'begin': '(^[ \\t]+)?(?=#)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.whitespace.comment.leading.sql'
-        'end': '(?!\\G)'
-        'patterns': [
-          {
-            'begin': '#'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.comment.sql'
-            'end': '\\n'
-            'name': 'comment.line.number-sign.sql'
-          }
-        ]
-      }
-      {
         'begin': '/\\*'
         'captures':
           '0':


### PR DESCRIPTION
MySQL comments starting with `#` are not standard and since they mess up syntax with temp tables in T-SQL, I suggest they should be removed from the package.