### PR TITLE
Added REGEXP support

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -110,7 +110,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using)\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike)\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {


### PR DESCRIPTION
According to https://dev.mysql.com/doc/refman/5.5/en/regexp.html REGEXP is a valid SQL keyword. Added it to the SQL grammar