### PR TITLE
`NOT REGEXP` and `NOT RLIKE`

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -110,7 +110,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|(not\\s+)?(regexp|rlike))\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike)\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {
@@ -132,6 +132,10 @@
   {
     'match': '(?i:(\\bnot\\s+)?\\bin\\b)'
     'name': 'keyword.other.data-integrity.sql'
+  }
+  {
+    'match': '(?i:\\bnot\\b)'
+    'name': 'keyword.other.not.sql'
   }
   {
     'match': '(?i:^\\s*(comment\\s+on\\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\\s+.*?\\s+(is)\\s+)'

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -110,7 +110,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike)\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|(not\\s+)?(regexp|rlike))\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -11,3 +11,7 @@ describe "SQL grammar", ->
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.sql"
+
+  it "uses not as a keyword", ->
+    {tokens} = grammar.tokenizeLine('NOT')
+    expect(tokens[0]).toEqual value: 'NOT', scopes: ['source.sql', 'keyword.other.not.sql']


### PR DESCRIPTION
I thought `NOT` was a keyword on its own, but it isn't, so I added `NOT REGEXP` and `NOT RLIKE` as keywords on their own