### PR TITLE
Hash / pound sign is not a comment character in sql

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -8,9 +8,6 @@
 ]
 'patterns': [
   {
-    'include': '#comments'
-  }
-  {
     'captures':
       '1':
         'name': 'keyword.other.create.sql'
@@ -219,23 +216,6 @@
         ]
       }
       {
-        'begin': '(^[ \\t]+)?(?=#)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.whitespace.comment.leading.sql'
-        'end': '(?!\\G)'
-        'patterns': [
-          {
-            'begin': '#'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.comment.sql'
-            'end': '\\n'
-            'name': 'comment.line.number-sign.sql'
-          }
-        ]
-      }
-      {
         'begin': '/\\*'
         'captures':
           '0':
@@ -291,7 +271,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.string.end.sql'
-    'match': '(#\\{)([^\\}]*)(\\})'
+    'match': '(\\{)([^\\}]*)(\\})'
     'name': 'string.interpolated.sql'
   'strings':
     'patterns': [
@@ -354,7 +334,7 @@
           '2':
             'name': 'punctuation.definition.string.end.sql'
         'comment': 'this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.'
-        'match': '(")[^"#]*(")'
+        'match': '(")[^"]*(")'
         'name': 'string.quoted.double.sql'
       }
       {


### PR DESCRIPTION
It is actually valid within identifiers. So a field my#field is valid, and is not a comment.