### PR TITLE
Add .psql to list of recognized SQL extensions

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -4,6 +4,7 @@
   'ddl'
   'dml'
   'pgsql'
+  'psql'
   'sql'
 ]
 'patterns': [


### PR DESCRIPTION
`.psql` seems to be a common PostgreSQL file name extension (my team uses it, WebStorm's most popular SQL plugin uses it). So I've added it to the list of recognized SQL extensions for this plugin.

Adding it ought not to cause collisions with other plugins.