### PR TITLE
Extend DROP keyword; add ADD keyword

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -28,8 +28,17 @@
         'name': 'keyword.other.create.sql'
       '2':
         'name': 'keyword.other.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view))'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view))'
     'name': 'meta.drop.sql'
+  }
+  {
+    'captures':
+      '1':
+        'name': 'keyword.other.create.sql'
+      '2':
+        'name': 'keyword.other.sql'
+    'match': '(?i:^\\s*(add)\\s+(check|constraint|(?:foreign|primary)\\s+key))'
+    'name': 'meta.add.sql'
   }
   {
     'captures':

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -30,9 +30,16 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('.123')
     expect(tokens[0]).toEqual value: '.123', scopes: ['source.sql', 'constant.numeric.sql']
 
+  it 'tokenizes add', ->
+    {tokens} = grammar.tokenizeLine('ADD CONSTRAINT')
+    expect(tokens[0]).toEqual value: 'ADD', scopes: ['source.sql', 'meta.add.sql', 'keyword.other.create.sql']
+
+  it 'tokenizes drop', ->
+    {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+
   it "quotes strings", ->
     {tokens} = grammar.tokenizeLine('"Test"')
     expect(tokens[0]).toEqual value: '"', scopes: ['source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
     expect(tokens[1]).toEqual value: 'Test', scopes: ['source.sql', 'string.quoted.double.sql']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.end.sql']
-    


### PR DESCRIPTION
Hi,

I've been using this package for a Databases class I'm taking, and it's proven quite useful (and aesthetically pleasing, naturally). However, I've noticed the package doesn't seem to highlight valid statements like ADD FOREIGN KEY and DROP CONSTRAINT.

<img width="500" alt="Syntax highlighting quirks" src="https://cloud.githubusercontent.com/assets/872474/14592637/b4196a6a-04d5-11e6-8ea1-7f3575600f9f.png">

Since this is a relatively simple issue to fix, I took the liberty of adding and extending the appropriate grammar rules. Please review my pull request for exactly what was added; I'd be happy to make any changes if need be.

Thanks,
Caleb