### PR TITLE
Added .dsql file extension

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -3,10 +3,10 @@
 'fileTypes': [
   'ddl'
   'dml'
+  'dsql'
   'pgsql'
   'psql'
   'sql'
-  'dsql'
 ]
 'patterns': [
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -6,6 +6,7 @@
   'pgsql'
   'psql'
   'sql'
+  'dsql'
 ]
 'patterns': [
   {


### PR DESCRIPTION
.dsql is used by Microsoft when interacting with their APS/PDW products. Same syntax as normal, just a different file extension.