### PR TITLE
Addition of T-SQL syntax: USE, GO, INTO, EXEC, OPENQUERY

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -147,7 +147,7 @@
     'name': 'keyword.other.DDL.create.II.sql'
   }
   {
-    'match': '(?i:\\b(values|use|exec|openquery)\\b)'
+    'match': '(?i:\\b(values|use|go|into|exec|openquery)\\b)'
     'name': 'keyword.other.DML.II.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -147,7 +147,7 @@
     'name': 'keyword.other.DDL.create.II.sql'
   }
   {
-    'match': '(?i:\\bvalues\\b)'
+    'match': '(?i:\\b(values|use|exec|openquery)\\b)'
     'name': 'keyword.other.DML.II.sql'
   }
   {


### PR DESCRIPTION
USE is used to select a database in SQL Server when a database is connected to.
EXEC and OPENQUERY are both used to get data on other servers.

I have grouped this with the VALUES keyword as EXEC/OPENQUERY are dealing with similar data.
I have also added USE into this dictionart as I felt it is cleaner than adding into dictionary keyword.other.DML.sql but let me know if you disagree.