### PR TITLE
Fixes #27 # being shown as comments in sql

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -247,23 +247,23 @@
           }
         ]
       }
-      {
-        'begin': '(^[ \\t]+)?(?=#)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.whitespace.comment.leading.sql'
-        'end': '(?!\\G)'
-        'patterns': [
-          {
-            'begin': '#'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.comment.sql'
-            'end': '\\n'
-            'name': 'comment.line.number-sign.sql'
-          }
-        ]
-      }
+      # {
+      #   'begin': '(^[ \\t]+)?(?=#)'
+      #   'beginCaptures':
+      #     '1':
+      #       'name': 'punctuation.whitespace.comment.leading.sql'
+      #   'end': '(?!\\G)'
+      #   'patterns': [
+      #     {
+      #       'begin': '#'
+      #       'beginCaptures':
+      #         '0':
+      #           'name': 'punctuation.definition.comment.sql'
+      #       'end': '\\n'
+      #       'name': 'comment.line.number-sign.sql'
+      #     }
+      #   ]
+      # }
       {
         'begin': '/\\*'
         'captures':


### PR DESCRIPTION
'#' and '##' are used to designate temporary tables in SQL

However, it is incorrectly highlighted as comments currently. Therefore, I have for testing purposes... ahem... commented out the # syntax highlighting in the comments section.

Fixes Issue #27