### PR TITLE
Fixes #26 for highlighting DECLARE

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -140,7 +140,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|between|and|(union|except)(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike)\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|use|declare|set|where|group\\s+by|or|like|between|and|(union|except)(\\s+all)?|having|order\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike)\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {
@@ -148,7 +148,7 @@
     'name': 'keyword.other.DDL.create.II.sql'
   }
   {
-    'match': '(?i:\\b(values|use|go|into|exec|openquery)\\b)'
+    'match': '(?i:\\b(values|go|into|exec|openquery)\\b)'
     'name': 'keyword.other.DML.II.sql'
   }
   {


### PR DESCRIPTION
1. Added highlighting for DECLARE keyword
2. Fixes the highlighting for USE keyword added in previous commit - now highlights correctly.

Fixes #26