### PR TITLE
Tokenize UNIQUE modifier

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -132,7 +132,7 @@
             '''
   }
   {
-    'match': '(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|check|constraint)\\b)'
+    'match': '(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|check|constraint|unique)\\b)'
     'name': 'storage.modifier.sql'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -55,6 +55,10 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('WITH field')
     expect(tokens[0]).toEqual value: 'WITH', scopes: ['source.sql', 'keyword.other.DML.sql']
 
+  it 'tokenizes unique', ->
+    {tokens} = grammar.tokenizeLine('UNIQUE(id)')
+    expect(tokens[0]).toEqual value: 'UNIQUE', scopes: ['source.sql', 'storage.modifier.sql']
+
   it 'tokenizes scalar functions', ->
     {tokens} = grammar.tokenizeLine('SELECT CURRENT_DATE')
     expect(tokens[2]).toEqual value: 'CURRENT_DATE', scopes: ['source.sql', 'support.function.scalar.sql']


### PR DESCRIPTION
Hi,

I recently discovered that the grammar for this package does not tokenize the SQL `UNIQUE` keyword. It's a standard SQL modifier (like `PRIMARY KEY`), so I think it should be tokenized.

I believe I've added everything required (including a passing unit test), but please let me know if you have any concerns or changes to request.

**Before:**

![screen shot 2016-10-26 at 9 09 23 pm](https://cloud.githubusercontent.com/assets/872474/19754310/07649dfc-9bc1-11e6-8b89-082f6e2678d5.png)


**After:**

![screen shot 2016-10-26 at 9 09 55 pm](https://cloud.githubusercontent.com/assets/872474/19754313/0b7f3474-9bc1-11e6-9fa0-050747d99900.png)

Thanks,
Caleb