### PR TITLE
Add intersect (all) keyword highlighting

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -140,7 +140,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|use|declare|set|where|group\\s+by|or|like|between|and|(union|except)(\\s+all)?|having|order\\s+by|partition\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike|with|exists)\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|use|declare|set|where|group\\s+by|or|like|between|and|(union|except|intersect)(\\s+all)?|having|order\\s+by|partition\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike|with|exists)\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {


### PR DESCRIPTION
Adds highlighting for intersect (all) keyword(s).

**Before**:
![screen shot 2016-11-16 at 14 07 21](https://cloud.githubusercontent.com/assets/16610775/20349315/3f403250-ac0a-11e6-87a2-d06c4112fdfe.png)

**After**:
![screen shot 2016-11-16 at 14 14 23](https://cloud.githubusercontent.com/assets/16610775/20349319/44df98b8-ac0a-11e6-8e5e-fc2e47cdba01.png)

