### PR TITLE
Tokenize DEFAULT modifier

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -132,7 +132,7 @@
             '''
   }
   {
-    'match': '(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|check|constraint|unique)\\b)'
+    'match': '(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|check|constraint|unique|default)\\b)'
     'name': 'storage.modifier.sql'
   }
   {


### PR DESCRIPTION
Hi,

This PR tokenizes the SQL `DEFAULT` modifier:

**Before:**  
<img width="425" alt="screen shot 2016-11-22 at 1 22 33 pm" src="https://cloud.githubusercontent.com/assets/872474/20542682/8103431a-b0b7-11e6-8ac0-e020183bb63d.png">

**After:**  
<img width="426" alt="screen shot 2016-11-22 at 1 22 45 pm" src="https://cloud.githubusercontent.com/assets/872474/20542689/876d377e-b0b7-11e6-8cd4-75c4c4e830ba.png">

I didn't feel any additional tests were necessary, since I assigned this modifier the same classification as the `UNIQUE` modifier (which I already added to the grammar with a test back in #46). All tests are still passing, though. :)