### PR TITLE
Extend CREATE/DROP to support IF EXISTS modifiers

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -22,7 +22,7 @@
         'name': 'keyword.other.DML.sql'
       '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)(?:([\'"`]?)(\\w+)\\5)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(\\s+if\\s+(?:not\\s+)?exists)?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
@@ -35,7 +35,7 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)(?:([\'"`]?)(\\w+)\\4)?'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(\\s+if\\s+(?:not\\s+)?exists)?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -22,7 +22,7 @@
         'name': 'keyword.other.DML.sql'
       '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+not\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\b(?:\\s+(if\\s+not\\s+exists)\\b)?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
@@ -35,7 +35,7 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\b(?:\\s+(if\\s+exists)\\b)?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -18,9 +18,11 @@
         'name': 'keyword.other.create.sql'
       '2':
         'name': 'keyword.other.sql'
-      '5':
+      '4':
+        'name': 'keyword.other.DML.sql'
+      '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+)([\'"`]?)(\\w+)\\4'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)([\'"`]?)(\\w+)\\5'
     'name': 'meta.create.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -20,36 +20,22 @@
         'name': 'keyword.other.sql'
       '4':
         'name': 'keyword.other.DML.sql'
-      '5':
-        'name': 'keyword.other.DML.sql'
       '6':
-        'name': 'keyword.other.DML.sql'
-      '7':
-        'name': 'punctuation.definition.string.begin.sql'
-      '8':
         'name': 'entity.name.function.sql'
-      '9':
-        'name': 'punctuation.definition.string.end.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if)\\s+(not)\\s+(exists))?)(?:\\s+([\'"`]?)(\\w+)\\7)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+not\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
     'captures':
       '1':
-        'name': 'keyword.other.drop.sql'
+        'name': 'keyword.other.create.sql'
       '2':
         'name': 'keyword.other.sql'
       '3':
         'name': 'keyword.other.DML.sql'
-      '4':
-        'name': 'keyword.other.DML.sql'
       '5':
-        'name': 'punctuation.definition.string.begin.sql'
-      '6':
         'name': 'entity.name.function.sql'
-      '7':
-        'name': 'punctuation.definition.string.end.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if)\\s+(exists))?)(?:\\s+([\'"`]?)(\\w+)(\\5))?'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -28,7 +28,7 @@
   {
     'captures':
       '1':
-        'name': 'keyword.other.create.sql'
+        'name': 'keyword.other.drop.sql'
       '2':
         'name': 'keyword.other.sql'
       '3':
@@ -50,7 +50,7 @@
   {
     'captures':
       '1':
-        'name': 'keyword.other.create.sql'
+        'name': 'keyword.other.drop.sql'
       '2':
         'name': 'keyword.other.table.sql'
       '3':

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -22,7 +22,7 @@
         'name': 'keyword.other.DML.sql'
       '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)([\'"`]?)(\\w+)\\5'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)(?:([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
@@ -35,7 +35,7 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)([\'"`]?)(\\w+)\\4'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)(?:([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -22,7 +22,7 @@
         'name': 'keyword.other.DML.sql'
       '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(\\s+if\\s+(?:not\\s+)?exists)?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+(?:not\\s+)?exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
@@ -35,7 +35,7 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(\\s+if\\s+(?:not\\s+)?exists)?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+(?:not\\s+)?exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -20,22 +20,36 @@
         'name': 'keyword.other.sql'
       '4':
         'name': 'keyword.other.DML.sql'
+      '5':
+        'name': 'keyword.other.DML.sql'
       '6':
+        'name': 'keyword.other.DML.sql'
+      '7':
+        'name': 'punctuation.definition.string.begin.sql'
+      '8':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+not\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
+      '9':
+        'name': 'punctuation.definition.string.end.sql'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if)\\s+(not)\\s+(exists))?)(?:\\s+([\'"`]?)(\\w+)\\7)?'
     'name': 'meta.create.sql'
   }
   {
     'captures':
       '1':
-        'name': 'keyword.other.create.sql'
+        'name': 'keyword.other.drop.sql'
       '2':
         'name': 'keyword.other.sql'
       '3':
         'name': 'keyword.other.DML.sql'
+      '4':
+        'name': 'keyword.other.DML.sql'
       '5':
+        'name': 'punctuation.definition.string.begin.sql'
+      '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
+      '7':
+        'name': 'punctuation.definition.string.end.sql'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if)\\s+(exists))?)(?:\\s+([\'"`]?)(\\w+)(\\5))?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -22,7 +22,7 @@
         'name': 'keyword.other.DML.sql'
       '6':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+(?:not\\s+)?exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+not\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\5)?'
     'name': 'meta.create.sql'
   }
   {
@@ -35,7 +35,7 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+(?:not\\s+)?exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)(?:\\s+(if\\s+exists))?)(?:\\s+([\'"`]?)(\\w+)\\4)?'
     'name': 'meta.drop.sql'
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -31,7 +31,11 @@
         'name': 'keyword.other.create.sql'
       '2':
         'name': 'keyword.other.sql'
-    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view))'
+      '3':
+        'name': 'keyword.other.DML.sql'
+      '5':
+        'name': 'entity.name.function.sql'
+    'match': '(?i:^\\s*(drop)\\s+(aggregate|check|constraint|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+(if\\s+(?:not\\s+)?exists\\s+)?)([\'"`]?)(\\w+)\\4'
     'name': 'meta.drop.sql'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -47,9 +47,27 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('ADD CONSTRAINT')
     expect(tokens[0]).toEqual value: 'ADD', scopes: ['source.sql', 'meta.add.sql', 'keyword.other.create.sql']
 
+  it 'tokenizes create', ->
+    {tokens} = grammar.tokenizeLine('CREATE TABLE')
+    expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
+
+  it 'tokenizes create if exists', ->
+    {tokens} = grammar.tokenizeLine('CREATE TABLE IF EXISTS t1')
+    expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
+    expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.sql' ]
+    expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
+
   it 'tokenizes drop', ->
     {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
     expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+
+  it 'tokenizes drop if exists', ->
+    {tokens} = grammar.tokenizeLine('DROP TABLE IF EXISTS t1')
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+    expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.sql' ]
+    expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes with', ->
     {tokens} = grammar.tokenizeLine('WITH field')

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -51,11 +51,11 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('CREATE TABLE')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
 
-  it 'tokenizes create if exists', ->
-    {tokens} = grammar.tokenizeLine('CREATE TABLE IF EXISTS t1')
+  it 'tokenizes create if not exists', ->
+    {tokens} = grammar.tokenizeLine('CREATE TABLE IF NOT EXISTS t1')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.sql' ]
-    expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[4]).toEqual value: 'IF NOT EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
     expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes drop', ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -55,22 +55,19 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('CREATE TABLE IF NOT EXISTS t1')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.sql' ]
-    expect(tokens[4]).toEqual value: 'IF', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[6]).toEqual value: 'NOT', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[8]).toEqual value: 'EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[10]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
+    expect(tokens[4]).toEqual value: 'IF NOT EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes drop', ->
     {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
 
   it 'tokenizes drop if exists', ->
     {tokens} = grammar.tokenizeLine('DROP TABLE IF EXISTS t1')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.sql' ]
-    expect(tokens[4]).toEqual value: 'IF', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[6]).toEqual value: 'EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[8]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]
+    expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes with', ->
     {tokens} = grammar.tokenizeLine('WITH field')

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -55,19 +55,22 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('CREATE TABLE IF NOT EXISTS t1')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.sql' ]
-    expect(tokens[4]).toEqual value: 'IF NOT EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
+    expect(tokens[4]).toEqual value: 'IF', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 'NOT', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[8]).toEqual value: 'EXISTS', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[10]).toEqual value: 't1', scopes: ['source.sql', 'meta.create.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes drop', ->
     {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
 
   it 'tokenizes drop if exists', ->
     {tokens} = grammar.tokenizeLine('DROP TABLE IF EXISTS t1')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.sql' ]
-    expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
-    expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]
+    expect(tokens[4]).toEqual value: 'IF', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[6]).toEqual value: 'EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
+    expect(tokens[8]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]
 
   it 'tokenizes with', ->
     {tokens} = grammar.tokenizeLine('WITH field')

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -60,11 +60,11 @@ describe "SQL grammar", ->
 
   it 'tokenizes drop', ->
     {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
 
   it 'tokenizes drop if exists', ->
     {tokens} = grammar.tokenizeLine('DROP TABLE IF EXISTS t1')
-    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.create.sql']
+    expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
     expect(tokens[2]).toEqual value: 'TABLE', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.sql' ]
     expect(tokens[4]).toEqual value: 'IF EXISTS', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.DML.sql' ]
     expect(tokens[6]).toEqual value: 't1', scopes: ['source.sql', 'meta.drop.sql', 'entity.name.function.sql' ]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -51,6 +51,10 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('CREATE TABLE')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
 
+  it 'does not tokenize create for non-SQL keywords', ->
+    {tokens} = grammar.tokenizeLine('CREATE TABLEOHNO')
+    expect(tokens[0]).toEqual value: 'CREATE TABLEOHNO', scopes: ['source.sql']
+
   it 'tokenizes create if not exists', ->
     {tokens} = grammar.tokenizeLine('CREATE TABLE IF NOT EXISTS t1')
     expect(tokens[0]).toEqual value: 'CREATE', scopes: ['source.sql', 'meta.create.sql', 'keyword.other.create.sql']
@@ -61,6 +65,10 @@ describe "SQL grammar", ->
   it 'tokenizes drop', ->
     {tokens} = grammar.tokenizeLine('DROP CONSTRAINT')
     expect(tokens[0]).toEqual value: 'DROP', scopes: ['source.sql', 'meta.drop.sql', 'keyword.other.drop.sql']
+
+  it 'does not tokenize drop for non-SQL keywords', ->
+    {tokens} = grammar.tokenizeLine('DROP CONSTRAINTOHNO')
+    expect(tokens[0]).toEqual value: 'DROP CONSTRAINTOHNO', scopes: ['source.sql']
 
   it 'tokenizes drop if exists', ->
     {tokens} = grammar.tokenizeLine('DROP TABLE IF EXISTS t1')


### PR DESCRIPTION
Some SQL dialects (particularly MySQL) support a very handy syntax for dropping and creating conditionally via the `IF NOT EXISTS` and `IF EXISTS` modifiers (respectively).

However, Atom does not currently tokenize these modifiers when used in `CREATE` and `DROP` statements:  
<img width="464" alt="before" src="https://cloud.githubusercontent.com/assets/872474/20552269/18c0a7b0-b0fe-11e6-91fb-ec40c03af720.png">

This PR extends the `CREATE` and `DROP` statements to support the `IF NOT EXISTS` and `IF EXISTS` modifiers:  
<img width="464" alt="after" src="https://cloud.githubusercontent.com/assets/872474/20552286/430641d8-b0fe-11e6-9992-dda6348fd950.png">

You'll notice my changes also have the added benefit of making the `CREATE` and `DROP` tokenization a bit more robust (see the `CREATE TABLE;` statement without arguments, as shown above).

To accompany these changes, I've added three new (passing) unit tests, and all existing tests continue to pass. Hooray for unit tests!

Anyway, thanks for considering this; please let me know if I need to make any further modifications.
Caleb