### PR TITLE
Adds highlighting of 'similar to'

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -140,7 +140,7 @@
     'name': 'constant.numeric.sql'
   }
   {
-    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|use|declare|set|where|group\\s+by|or|like|between|and|(union|except|intersect)(\\s+all)?|having|order\\s+by|partition\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike|with|exists)\\b)'
+    'match': '(?i:\\b(select(\\s+distinct)?|insert\\s+(ignore\\s+)?into|update|delete|from|use|declare|set|where|group\\s+by|or|like|(similar\\sto)|between|and|(union|except|intersect)(\\s+all)?|having|order\\s+by|partition\\s+by|limit|offset|(inner|cross)\\s+join|join|straight_join|(left|right)(\\s+outer)?\\s+join|natural(\\s+(left|right)(\\s+outer)?)?\\s+join|using|regexp|rlike|with|exists)\\b)'
     'name': 'keyword.other.DML.sql'
   }
   {


### PR DESCRIPTION
This PR adds support for 'similar to' keyword. It is included in PSQL as well as DSQL, and shouldn't be too controversial.

Befor
![screendump 2016-11-26 at 16 21 56](https://cloud.githubusercontent.com/assets/16610775/20641346/3e0c2422-b3f6-11e6-982b-73c880a5c3b6.png)
e:

After:
![screendump 2016-11-26 at 16 21 18](https://cloud.githubusercontent.com/assets/16610775/20641347/44b43e7c-b3f6-11e6-8286-4eeb65909b92.png)
