### PR TITLE
Highlight timestamptz type

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -128,7 +128,7 @@
               |\\b(times)(?:\\((\\d+)\\))(\\swithoutstimeszone\\b)?
 
               # special case, captures 12, 13, 14i, 15
-              |\\b(timestamp|time)\\b(?:(s)\\((\\d+)\\)(\\swithoutstimeszone\\b)?)?
+              |\\b(timestamp(tz)?|time)\\b(?:(s)\\((\\d+)\\)(\\swithoutstimeszone\\b)?)?
             '''
   }
   {


### PR DESCRIPTION
### Description of the Change

- Highlight `timestamptz` data type
  - a data type that's supported by PostgreSQL, Redshift (, also Oracle?)

### Benefits

Improve visibility of `timestamptz` in SQL queries

- before

![timestamptz_before](https://cloud.githubusercontent.com/assets/354940/21514738/fa199464-cd0b-11e6-9c49-7953eeb893bb.png)

- after

![timestamptz_after](https://cloud.githubusercontent.com/assets/354940/21514886/b8e07c4a-cd0d-11e6-84ee-4653660dbd46.png)

### Possible Drawbacks

- none

### Applicable Issues

- none
