### PR TITLE
Added .mysql to list of relevant files

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -6,6 +6,7 @@
   'dsql'
   'pgsql'
   'psql'
+  'mysql'
   'sql'
 ]
 'patterns': [


### PR DESCRIPTION
### Description of the Change

Added 'mysql' to list of file endings to work with.

### Alternate Designs

Users have to try to change that on their end? Install forked and possibly not maintained version just for mysql: https://atom.io/packages/language-sql-mysql I'd prefer plugin to do it's best guess for mysql.

### Benefits

Just as people use pgsql for postgres people use .mysql for mysql/mariadb files.  Now they are colorized etc, without needing to be renamed to .sql.

### Possible Drawbacks

Namespace collision? Expectation of specific action for mysql files?  There is a fork that adds mysql specific stuff.  Perhaps that's the right approach? https://atom.io/packages/language-sql-mysql

### Applicable Issues

None.
