### PR TITLE
Added .q to list of relevant files (HiveQL)

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -6,6 +6,7 @@
   'dsql'
   'pgsql'
   'psql'
+  'q'
   'sql'
 ]
 'patterns': [


### PR DESCRIPTION
### Description of the Change

Added 'q' to list of file endings to work with.

### Alternate Designs

Could fork into another project.

### Benefits

Lots of teams working with Hadoop, Big Data, and Data Science projects are creating HiveQL scripts. The standard extension for HiveQL is '.q'

### Possible Drawbacks

Much of HiveQL is nearly ANSI standard, but in essence is a subset. Some specific HiveQL keywords may not be captured/highlighted. Would require further refinement in this package.

### Applicable Issues

None.
