### PR TITLE
Correct time/timestamp grammar matches

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -124,7 +124,7 @@
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?
 
               # special case, captures 9, 10i, 11
-              |\\b(time(?:stamp)?)\\b\\s*(?:\\(\\s*(\\d+)\\s*\\))?\\s*(with(?:out)?\\s+time\\s+zone\\b)?
+              |\\b(time(?:stamp)?)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?\\s*(with(?:out)?\\s+time\\s+zone\\b)?
             '''
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -118,7 +118,7 @@
               |\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)
 
               # optional numeric suffix, capture 4 + 5i
-              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b\\s*(?:\\(\\s*(\\d+)\\)\\s*)?
+              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\)\\s*)?
 
               # special case, capture 6 + 7i + 8i
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -118,13 +118,13 @@
               |\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)
 
               # optional numeric suffix, capture 4 + 5i
-              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\)\\s*)?
+              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\)\\s*)?
 
               # special case, capture 6 + 7i + 8i
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?
 
               # special case, captures 9, 10i, 11
-              |\\b(time(?:stamp)?)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?\\s*(with(?:out)?\\s+time\\s+zone\\b)?
+              |\\b(time(?:stamp)?)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?(?:\\s*(with(?:out)?\\s+time\\s+zone\\b))?
             '''
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -112,11 +112,7 @@
       '12':
         'name': 'storage.type.sql'
       '13':
-        'name': 'storage.type.sql'
-      '14':
         'name': 'constant.numeric.sql'
-      '15':
-        'name': 'storage.type.sql'
     'match': '''
               (?xi)
               # normal stuff, capture 1
@@ -132,10 +128,10 @@
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?
 
               # special case, captures 9, 10i, 11
-              |\\b(times)(?:\\((\\d+)\\))(\\swithoutstimeszone\\b)?
+              |\\b(time(?:stamp)?)\\b\\s*(?:\\(\\s*(\\d+)\\s*\\))?\\s*(with(?:out)?\\s+time\\s+zone\\b)?
 
-              # special case, captures 12, 13, 14i, 15
-              |\\b(timestamp(tz)?|time)\\b(?:(s)\\((\\d+)\\)(\\swithoutstimeszone\\b)?)?
+              # special case, captures 12, 13i
+              |\\b(time(?:stamp)?tz)\\b\\s*(?:\\(\\s*(\\d+)\\)\\s*)?
             '''
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -109,10 +109,6 @@
         'name': 'constant.numeric.sql'
       '11':
         'name': 'storage.type.sql'
-      '12':
-        'name': 'storage.type.sql'
-      '13':
-        'name': 'constant.numeric.sql'
     'match': '''
               (?xi)
               # normal stuff, capture 1
@@ -122,16 +118,13 @@
               |\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)
 
               # optional numeric suffix, capture 4 + 5i
-              |\\b(char|number|n?varchar\\d?)\\b(?:\\((\\d+)\\))?
+              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b\\s*(?:\\(\\s*(\\d+)\\)\\s*)?
 
               # special case, capture 6 + 7i + 8i
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?
 
               # special case, captures 9, 10i, 11
               |\\b(time(?:stamp)?)\\b\\s*(?:\\(\\s*(\\d+)\\s*\\))?\\s*(with(?:out)?\\s+time\\s+zone\\b)?
-
-              # special case, captures 12, 13i
-              |\\b(time(?:stamp)?tz)\\b\\s*(?:\\(\\s*(\\d+)\\)\\s*)?
             '''
   }
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -118,7 +118,7 @@
               |\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)
 
               # optional numeric suffix, capture 4 + 5i
-              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\)\\s*)?
+              |\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?
 
               # special case, capture 6 + 7i + 8i
               |\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -102,3 +102,32 @@ describe "SQL grammar", ->
     expect(tokens[0]).toEqual value: '"', scopes: ['source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
     expect(tokens[1]).toEqual value: 'Test', scopes: ['source.sql', 'string.quoted.double.sql']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.end.sql']
+
+  it 'tokenizes time types', ->
+    {tokens} = grammar.tokenizeLine('TIME')
+    expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('TIME(1)WITHOUT TIME ZONE\'23:00\'')
+    expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: '1', scopes: ['source.sql', 'constant.numeric.sql']
+    expect(tokens[4]).toEqual value: 'WITHOUT TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('TIMESTAMP ( 12 )  WITH TIME ZONE')
+    expect(tokens[0]).toEqual value: 'TIMESTAMP', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: '12', scopes: ['source.sql', 'constant.numeric.sql']
+    expect(tokens[4]).toEqual value: 'WITH TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('TIME WITH TIME ZONE')
+    expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: 'WITH TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('timetz (2)')
+    expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']
+
+    {tokens} = grammar.tokenizeLine('timestamptz')
+    expect(tokens[0]).toEqual value: 'timestamptz', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('TIMESTAMPTZ(2)NOT NULL')
+    expect(tokens[0]).toEqual value: 'TIMESTAMPTZ', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -103,35 +103,34 @@ describe "SQL grammar", ->
     expect(tokens[1]).toEqual value: 'Test', scopes: ['source.sql', 'string.quoted.double.sql']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.end.sql']
 
-  it 'tokenizes time types', ->
+  it 'tokenizes the time type', ->
     {tokens} = grammar.tokenizeLine('TIME')
     expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
+
+    {tokens} = grammar.tokenizeLine('TIME WITH TIME ZONE')
+    expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: 'WITH TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
 
     {tokens} = grammar.tokenizeLine('TIME(1)WITHOUT TIME ZONE\'23:00\'')
     expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
     expect(tokens[2]).toEqual value: '1', scopes: ['source.sql', 'constant.numeric.sql']
     expect(tokens[4]).toEqual value: 'WITHOUT TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
 
+  it 'tokenizes the timestamp type', ->
     {tokens} = grammar.tokenizeLine('TIMESTAMP ( 12 )  WITH TIME ZONE')
     expect(tokens[0]).toEqual value: 'TIMESTAMP', scopes: ['source.sql', 'storage.type.sql']
     expect(tokens[2]).toEqual value: '12', scopes: ['source.sql', 'constant.numeric.sql']
     expect(tokens[4]).toEqual value: 'WITH TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
 
-    {tokens} = grammar.tokenizeLine('TIME WITH TIME ZONE')
-    expect(tokens[0]).toEqual value: 'TIME', scopes: ['source.sql', 'storage.type.sql']
-    expect(tokens[2]).toEqual value: 'WITH TIME ZONE', scopes: ['source.sql', 'storage.type.sql']
-
-    {tokens} = grammar.tokenizeLine('timetz (2)')
-    expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
-    expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']
-
+  it 'tokenizes the timestamptz type', ->
     {tokens} = grammar.tokenizeLine('timestamptz')
     expect(tokens[0]).toEqual value: 'timestamptz', scopes: ['source.sql', 'storage.type.sql']
 
-    {tokens} = grammar.tokenizeLine('timetz (\'01:59\' || \' UTC+3\')')
-    expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
-    expect(tokens[1]).toEqual value: ' (', scopes: ['source.sql']
-
     {tokens} = grammar.tokenizeLine('TIMESTAMPTZ(2)NOT NULL')
     expect(tokens[0]).toEqual value: 'TIMESTAMPTZ', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']
+
+  it 'tokenizes the timetz type', ->
+    {tokens} = grammar.tokenizeLine('timetz (2)')
+    expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
     expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -128,6 +128,10 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('timestamptz')
     expect(tokens[0]).toEqual value: 'timestamptz', scopes: ['source.sql', 'storage.type.sql']
 
+    {tokens} = grammar.tokenizeLine('timetz (\'01:59\' || \' UTC+3\')')
+    expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
+    expect(tokens[1]).toEqual value: ' (', scopes: ['source.sql']
+
     {tokens} = grammar.tokenizeLine('TIMESTAMPTZ(2)NOT NULL')
     expect(tokens[0]).toEqual value: 'TIMESTAMPTZ', scopes: ['source.sql', 'storage.type.sql']
     expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']


### PR DESCRIPTION
### Description of the Change

The keywords for `time` and `timestamp` do not appear to work as intended.

This issue is explained in textmate/sql.tmbundle#11 and has been duplicated when the code was converted for Atom.

> These strings are highlighted:
>
>`times(123) withoutstimeszone`
>`timestamps(123) withoutstimeszone`
>
>But it appears that the regular expressions were intended to match "without time zone", intended to make the 's' on timestamp optional, and to make the numeric constant in parentheses optional. As it is, it only works "withoutstimeszone" and the numeric constant must be present to get the time zone string.

This change fixes the issue.

The fix in the Textmate project replaces
`|\b(times)(?:\((\d+)\))(\swithoutstimeszone\b)?`
with
`|\b(times?)\b(?:\((\d+)\))?(\swith(?:out)?\stime\szone\b)?`

and

`|\b(timestamp)(?:(s)\((\d+)\)(\swithoutstimeszone\b)?)?`
with
`|\b(timestamp)(?:(s|tz))?\b(?:\((\d+)\))?(\s(with|without)\stime\szone\b)?`

However I could find no mention of `times` and `timestamps` being types in any dialect of SQL and assume this must have been caused by missing escapes for whitespace characters `\s`.
Additionally `timestamptz` is shorthand for `timestamp with time zone` and so should not capture any `with time zone` or `without time zone` modifier.
When implementing I have added greater whitespace tolerance allowing multiple characters whereas before only a single character or none was allowed.

I have replaced the grammar for types without the tz suffix to become:
`|\\b(time(?:stamp)?)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?(?:\\s*(with(?:out)?\\s+time\\s+zone\\b))?`
which combines the unnecessarily separated time and timestamp patterns.

Now `timestamptz` fits in with similar types like `varchar` that have an optional suffix. I have also added the similar type shorthand `timetz`:
`|\\b(char|number|n?varchar\\d?|time(?:stamp)?tz)\\b(?:\\s*\\(\\s*(\\d+)\\s*\\))?`



<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

It is possible make `with time zone` and `without time zone` match on their own as part of a type definition, therefore allowing this part to be recognised across a new line. However, CTEs use the keyword `with` and I am not certain how the two would interact.

The `timetz` and `timestamptz` are grouped together with other optional numeric arguments. However these could all be moved to the matching group for types without such arguments since numeric constants are already matched on their own.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

The grammar parser will now recognise `timestamp (1) without time zone` phrases and (similar with `time`) with the precision specifying component and the time zone clause optional, whereas previously it only recognised the `timestamp` portion before incorrect matching.

The `timetz` and `timestamptz` can now be included in the matches for types with an optional numeric suffix such as `varchar`, and will not incorrectly match a subsequent `without time zone` clause.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

If `times` or `timestamps` are types in any dialect of SQL, these would be removed.

Correctly recognising key words could cause conflicts with entities such as columns named in dialects that lack these keywords and so share names. This does not seem like a likely occurrence though.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Apart from `timetz` everything is just making the grammar work as intended. The type shorthand `timetz` does not appear to be listed in the documentation for PostgreSQL, but it is recognised by it nonetheless.
<!-- Enter any applicable Issues here -->
