### PR TITLE
Added .hql format for Hive SQL (big data) files

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -4,11 +4,11 @@
   'ddl'
   'dml'
   'dsql'
+  'hql'
   'pgsql'
   'psql'
   'q'
   'sql'
-  'hql'
 ]
 'patterns': [
   {

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -8,6 +8,7 @@
   'psql'
   'q'
   'sql'
+  'hql'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Added .hql format to list of known file extentions to handle hive SQL files (.hql). Hive is part of Hadoop and is used for big data applications. 