### PR TITLE
Clean up comment regexes

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -237,29 +237,23 @@
   'comments':
     'patterns': [
       {
-        'begin': '(^[ \\t]+)?(?=--)'
+        'begin': '--'
         'beginCaptures':
-          '1':
-            'name': 'punctuation.whitespace.comment.leading.sql'
-        'end': '(?!\\G)'
-        'patterns': [
-          {
-            'begin': '--'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.comment.sql'
-            'end': '\\n'
-            'name': 'comment.line.double-dash.sql'
-          }
-        ]
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'end': '$'
+        'name': 'comment.line.double-dash.sql'
       }
       {
         'begin': '/\\*'
-        'captures':
+        'beginCaptures':
           '0':
             'name': 'punctuation.definition.comment.sql'
         'end': '\\*/'
-        'name': 'comment.block.c'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'name': 'comment.block.sql'
       }
     ]
   'regexps':

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -140,7 +140,20 @@ describe "SQL grammar", ->
     expect(tokens[0]).toEqual value: '--', scopes: ['source.sql', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
     expect(tokens[1]).toEqual value: ' comment', scopes: ['source.sql', 'comment.line.double-dash.sql']
 
+    {tokens} = grammar.tokenizeLine('AND -- WITH')
+
+    expect(tokens[0]).toEqual value: 'AND', scopes: ['source.sql', 'keyword.other.DML.sql']
+    expect(tokens[2]).toEqual value: '--', scopes: ['source.sql', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
+    expect(tokens[3]).toEqual value: ' WITH', scopes: ['source.sql', 'comment.line.double-dash.sql']
+
     {tokens} = grammar.tokenizeLine('/* comment */')
     expect(tokens[0]).toEqual value: '/*', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']
     expect(tokens[1]).toEqual value: ' comment ', scopes: ['source.sql', 'comment.block.sql']
     expect(tokens[2]).toEqual value: '*/', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']
+
+    {tokens} = grammar.tokenizeLine('SELECT /* WITH */ AND')
+    expect(tokens[0]).toEqual value: 'SELECT', scopes: ['source.sql', 'keyword.other.DML.sql']
+    expect(tokens[2]).toEqual value: '/*', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']
+    expect(tokens[3]).toEqual value: ' WITH ', scopes: ['source.sql', 'comment.block.sql']
+    expect(tokens[4]).toEqual value: '*/', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']
+    expect(tokens[6]).toEqual value: 'AND', scopes: ['source.sql', 'keyword.other.DML.sql']

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -134,3 +134,13 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('timetz (2)')
     expect(tokens[0]).toEqual value: 'timetz', scopes: ['source.sql', 'storage.type.sql']
     expect(tokens[2]).toEqual value: '2', scopes: ['source.sql', 'constant.numeric.sql']
+
+  it 'tokenizes comments', ->
+    {tokens} = grammar.tokenizeLine('-- comment')
+    expect(tokens[0]).toEqual value: '--', scopes: ['source.sql', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
+    expect(tokens[1]).toEqual value: ' comment', scopes: ['source.sql', 'comment.line.double-dash.sql']
+
+    {tokens} = grammar.tokenizeLine('/* comment */')
+    expect(tokens[0]).toEqual value: '/*', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']
+    expect(tokens[1]).toEqual value: ' comment ', scopes: ['source.sql', 'comment.block.sql']
+    expect(tokens[2]).toEqual value: '*/', scopes: ['source.sql', 'comment.block.sql', 'punctuation.definition.comment.sql']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

They were overly complicated and causing bugs such as https://github.com/atom/language-php/issues/187.  Simplify them.

### Alternate Designs

None.

### Benefits

Easier to understand, less conflicts with other rules due to the removal of the `^` start-of-line match.

### Possible Drawbacks

None.

### Applicable Issues

Fixes atom/language-php#187