### PR TITLE
Highlight bare float type

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -113,7 +113,7 @@
     'match': '''
               (?xi)
               # normal stuff, capture 1
-              \\b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|datetime|double\\sprecision|enum|inet|int|integer|line|lseg|macaddr|money|oid|path|point|polygon|real|serial|smallint|sysdate|text)\\b
+              \\b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|datetime|double\\sprecision|enum|inet|int|integer|line|lseg|macaddr|money|oid|path|point|polygon|real|float|serial|smallint|sysdate|text)\\b
 
               # numeric suffix, capture 2 + 3i
               |\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)


### PR DESCRIPTION
### Description of the Change

- Highlight `float` as a data type
  - `float` without precision is supported by Amazon Redshift and Oracle

### Benefits

Improve visibility of timestamptz in SQL queries

- before

<img width="292" alt="float_before" src="https://user-images.githubusercontent.com/354940/27157033-9b860378-5114-11e7-9e02-d4813afd589f.png">

- after

<img width="285" alt="float_after" src="https://user-images.githubusercontent.com/354940/27157048-a59a37ee-5114-11e7-9378-0b0eec8aa8c0.png">
