### PR TITLE
Add highlight of a few conditional expressions (COALESCE, NVL, and NULLIF)

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -182,7 +182,7 @@
   }
   {
     'match': '(?i)\\b(coalesce|nvl|nullif)\\b'
-    'name': 'keyword.other.conditional_expression.sql'
+    'name': 'keyword.other.conditional.sql'
   }
   {
     'match': '\\*'

--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -181,6 +181,10 @@
     'name': 'keyword.other.case.sql'
   }
   {
+    'match': '(?i)\\b(coalesce|nvl|nullif)\\b'
+    'name': 'keyword.other.conditional_expression.sql'
+  }
+  {
     'match': '\\*'
     'name': 'keyword.operator.star.sql'
   }

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -83,13 +83,13 @@ describe "SQL grammar", ->
 
   it 'tokenizes conditional expressions', ->
     {tokens} = grammar.tokenizeLine('COALESCE(a,b)')
-    expect(tokens[0]).toEqual value: 'COALESCE', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+    expect(tokens[0]).toEqual value: 'COALESCE', scopes: ['source.sql', 'keyword.other.conditional.sql']
 
     {tokens} = grammar.tokenizeLine('NVL(a,b)')
-    expect(tokens[0]).toEqual value: 'NVL', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+    expect(tokens[0]).toEqual value: 'NVL', scopes: ['source.sql', 'keyword.other.conditional.sql']
 
     {tokens} = grammar.tokenizeLine('NULLIF(a,b)')
-    expect(tokens[0]).toEqual value: 'NULLIF', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+    expect(tokens[0]).toEqual value: 'NULLIF', scopes: ['source.sql', 'keyword.other.conditional.sql']
 
   it 'tokenizes unique', ->
     {tokens} = grammar.tokenizeLine('UNIQUE(id)')

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -81,6 +81,16 @@ describe "SQL grammar", ->
     {tokens} = grammar.tokenizeLine('WITH field')
     expect(tokens[0]).toEqual value: 'WITH', scopes: ['source.sql', 'keyword.other.DML.sql']
 
+  it 'tokenizes conditional expressions', ->
+    {tokens} = grammar.tokenizeLine('COALESCE(a,b)')
+    expect(tokens[0]).toEqual value: 'COALESCE', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+
+    {tokens} = grammar.tokenizeLine('NVL(a,b)')
+    expect(tokens[0]).toEqual value: 'NVL', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+
+    {tokens} = grammar.tokenizeLine('NULLIF(a,b)')
+    expect(tokens[0]).toEqual value: 'NULLIF', scopes: ['source.sql', 'keyword.other.conditional_expression.sql']
+
   it 'tokenizes unique', ->
     {tokens} = grammar.tokenizeLine('UNIQUE(id)')
     expect(tokens[0]).toEqual value: 'UNIQUE', scopes: ['source.sql', 'storage.modifier.sql']


### PR DESCRIPTION
### Description of the Change

- Add highlight for a few conditional expressions: `COALESCE`, `NVL`, and `NULLIF`
  - these expressions are available on PostgreSQL, MySQL, Oracle, Amazon Redshift, and more

I hope specs which I added work well 🙏 

### Benefits

Improve visibility of these keywords in SQL queries

### Before

<img width="255" alt="screen shot 2017-07-10 at 14 54 44" src="https://user-images.githubusercontent.com/354940/28042014-629e8c6c-6580-11e7-8ceb-962e66863f64.png">

### After

<img width="279" alt="screen shot 2017-07-10 at 14 51 52" src="https://user-images.githubusercontent.com/354940/28042021-6a64caba-6580-11e7-8930-1b42f48f28b1.png">
